### PR TITLE
Add peripheral id construction from uuid and index

### DIFF
--- a/src/types/peripheral_id.rs
+++ b/src/types/peripheral_id.rs
@@ -9,6 +9,9 @@ pub struct PeripheralId {
 }
 
 impl PeripheralId {
+    pub fn new(uuid: String, index: String) -> PeripheralId {
+        PeripheralId { uuid, index }
+    }
     pub fn uuid(&self) -> &str {
         &self.uuid
     }


### PR DESCRIPTION
Saves a String allocation if we already have the uuid and index separated