### PR TITLE
Add Organizations AWS client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ services_lambda = [
 ]
 services_organizations = [
   "aws-config",
-  "aws-sdk-lambda",
+  "aws-sdk-organizations",
   "aws-types",
   "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ aws-sdk-cognitoidentityprovider = { version = "0.9", optional = true }
 aws-sdk-dynamodb = { version = "0.9", optional = true }
 aws-sdk-dynamodbstreams = { version = "0.9", optional = true }
 aws-sdk-lambda = { version = "0.9", optional = true }
+aws-sdk-organizations = { version = "0.9.0", optional = true }
 aws-sdk-s3 = { version = "0.9", optional = true }
 aws-sdk-secretsmanager = { version = "0.9", optional = true }
 aws-sdk-ssm = { version = "0.9", optional = true }
@@ -70,6 +71,12 @@ services_dynamodb = [
   "tokio",
 ]
 services_lambda = [
+  "aws-config",
+  "aws-sdk-lambda",
+  "aws-types",
+  "tokio",
+]
+services_organizations = [
   "aws-config",
   "aws-sdk-lambda",
   "aws-types",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,10 +7,11 @@ pub mod misc;
     feature = "services_cognitoidentityprovider",
     feature = "services_dynamodb",
     feature = "services_lambda",
+    feature = "services_organizations",
     feature = "services_s3",
     feature = "services_secretsmanager",
     feature = "services_ssm",
-    feature = "services_sts"
+    feature = "services_sts",
 ))]
 pub mod services;
 #[cfg(feature = "types")]

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -4,6 +4,8 @@ pub mod cloudformation;
 pub mod cognitoidentityprovider;
 #[cfg(feature = "services_dynamodb")]
 pub mod dynamodb;
+#[cfg(feature = "services_organizations")]
+pub mod organizations;
 #[cfg(feature = "services_s3")]
 pub mod s3;
 #[cfg(feature = "services_secretsmanager")]

--- a/src/services/organizations.rs
+++ b/src/services/organizations.rs
@@ -1,0 +1,15 @@
+use crate::services::in_region;
+use aws_sdk_organizations::Client as OrganizationsClient;
+use tokio::sync::OnceCell;
+
+async fn organizations_client(region: Option<&'static str>) -> OrganizationsClient {
+    OrganizationsClient::new(&in_region(region).await)
+}
+
+static ORGANIZATIONS: OnceCell<OrganizationsClient> = OnceCell::const_new();
+
+pub async fn organizations<'client>(region: Option<&'static str>) -> &'client OrganizationsClient {
+    ORGANIZATIONS
+        .get_or_init(|| organizations_client(region))
+        .await
+}


### PR DESCRIPTION
For use with our MGMT API in order to list the available private clouds (account ids).