### PR TITLE
Reexport aws crates for services

### DIFF
--- a/src/services/cloudformation.rs
+++ b/src/services/cloudformation.rs
@@ -2,6 +2,9 @@ use crate::services::in_region;
 use aws_sdk_cloudformation::Client as CloudformationClient;
 use tokio::sync::OnceCell;
 
+// Re-export
+pub use aws_sdk_cloudformation;
+
 async fn cloudformation_client(region: Option<&'static str>) -> CloudformationClient {
     CloudformationClient::new(&in_region(region).await)
 }

--- a/src/services/cognitoidentityprovider.rs
+++ b/src/services/cognitoidentityprovider.rs
@@ -2,6 +2,9 @@ use crate::services::in_region;
 use aws_sdk_cognitoidentityprovider::Client as CognitoIDPClient;
 use tokio::sync::OnceCell;
 
+// Re-export
+pub use aws_sdk_cognitoidentityprovider;
+
 async fn cognito_client(region: Option<&'static str>) -> CognitoIDPClient {
     CognitoIDPClient::new(&in_region(region).await)
 }

--- a/src/services/dynamodb.rs
+++ b/src/services/dynamodb.rs
@@ -3,6 +3,9 @@ use aws_types::region::Region;
 use http::Uri;
 use tokio::sync::OnceCell;
 
+// Re-export
+pub use aws_sdk_dynamodb;
+
 async fn dynamodb_client(region: Option<&'static str>) -> DynamoDBClient {
     let config_builder = aws_config::from_env();
 

--- a/src/services/organizations.rs
+++ b/src/services/organizations.rs
@@ -2,6 +2,9 @@ use crate::services::in_region;
 use aws_sdk_organizations::Client as OrganizationsClient;
 use tokio::sync::OnceCell;
 
+// Re-export
+pub use aws_sdk_organizations;
+
 async fn organizations_client(region: Option<&'static str>) -> OrganizationsClient {
     OrganizationsClient::new(&in_region(region).await)
 }

--- a/src/services/s3.rs
+++ b/src/services/s3.rs
@@ -2,6 +2,9 @@ use crate::services::in_region;
 use aws_sdk_s3::Client as S3Client;
 use tokio::sync::OnceCell;
 
+// Re-export
+pub use aws_sdk_s3;
+
 async fn s3_client(region: Option<&'static str>) -> S3Client {
     S3Client::new(&in_region(region).await)
 }

--- a/src/services/secretsmanager.rs
+++ b/src/services/secretsmanager.rs
@@ -2,6 +2,9 @@ use crate::services::in_region;
 use aws_sdk_secretsmanager::Client as SecretsManagerClient;
 use tokio::sync::OnceCell;
 
+// Re-export
+pub use aws_sdk_secretsmanager;
+
 async fn secrets_manager_client(region: Option<&'static str>) -> SecretsManagerClient {
     SecretsManagerClient::new(&in_region(region).await)
 }

--- a/src/services/ssm.rs
+++ b/src/services/ssm.rs
@@ -2,6 +2,9 @@ use crate::services::in_region;
 use aws_sdk_ssm::Client as SSMClient;
 use tokio::sync::OnceCell;
 
+// Re-export
+pub use aws_sdk_ssm;
+
 async fn ssm_client(region: Option<&'static str>) -> SSMClient {
     SSMClient::new(&in_region(region).await)
 }

--- a/src/services/sts.rs
+++ b/src/services/sts.rs
@@ -2,6 +2,9 @@ use crate::services::in_region;
 use aws_sdk_sts::Client as STSClient;
 use tokio::sync::OnceCell;
 
+// Re-export
+pub use aws_sdk_sts;
+
 async fn sts_client(region: Option<&'static str>) -> STSClient {
     STSClient::new(&in_region(region).await)
 }


### PR DESCRIPTION
This is useful so that users of bb_rust can just depend on bb_rust's version of the aws crate, instead of also specifying the version in their own cargo.toml file.
With this change, if aws crates need updating, it is only needed to update bb_rust, and then use that version wherever bb_rust was used