### PR TITLE
Fix caching of multiple regions for same client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ aws-sdk-ssm = {version = "0.9", optional = true}
 aws-sdk-sts = {version = "0.9", optional = true}
 aws-types = {version = "0.9", optional = true}
 base64 = {version = "0.13", optional = true}
+cached = {version = "0.34", optional = true}
 env_logger = {version = "0.9", optional = true}
 flate2 = {version = "1", optional = true}
 graphql_client = {version = "0.10", optional = true}
@@ -40,7 +41,6 @@ serde_bytes = {version = "0.11", optional = true}
 serde_json = {version = "1", optional = true}
 serde_with = {version = "1", features = ["json"], optional = true}
 thiserror = {version = "1", optional = true}
-tokio = {optional = true, version = "1", default_features = false, features = ["parking_lot"]}
 
 [dev-dependencies]
 anyhow = "1"
@@ -58,19 +58,19 @@ services_apigateway = [
   "aws-config",
   "aws-sdk-apigateway",
   "aws-types",
-  "tokio",
+  "cached",
 ]
 services_cloudformation = [
   "aws-config",
   "aws-sdk-cloudformation",
   "aws-types",
-  "tokio",
+  "cached",
 ]
 services_cognitoidentityprovider = [
   "aws-config",
   "aws-sdk-cognitoidentityprovider",
   "aws-types",
-  "tokio",
+  "cached",
 ]
 services_dynamodb = [
   "aws-config",
@@ -78,48 +78,48 @@ services_dynamodb = [
   "aws-sdk-dynamodbstreams",
   "aws-types",
   "http",
-  "tokio",
+  "cached",
 ]
 services_iot = [
   "aws-config",
   "aws-sdk-iot",
   "aws-types",
-  "tokio",
+  "cached",
 ]
 services_lambda = [
   "aws-config",
   "aws-sdk-lambda",
   "aws-types",
-  "tokio",
+  "cached",
 ]
 services_organizations = [
   "aws-config",
   "aws-sdk-organizations",
   "aws-types",
-  "tokio",
+  "cached",
 ]
 services_s3 = [
   "aws-config",
   "aws-sdk-s3",
   "aws-types",
-  "tokio",
+  "cached",
 ]
 services_secretsmanager = [
   "aws-config",
   "aws-sdk-secretsmanager",
   "aws-types",
-  "tokio",
+  "cached",
 ]
 services_ssm = [
   "aws-config",
   "aws-sdk-ssm",
   "aws-types",
-  "tokio",
+  "cached",
 ]
 services_sts = [
   "aws-config",
   "aws-sdk-sts",
   "aws-types",
-  "tokio",
+  "cached",
 ]
 types = ["serde", "thiserror"]

--- a/src/services/apigateway.rs
+++ b/src/services/apigateway.rs
@@ -1,16 +1,11 @@
 use crate::services::in_region;
 use aws_sdk_apigateway::Client as ApiGatewayClient;
-use tokio::sync::OnceCell;
+use cached::proc_macro::cached;
 
 // Re-export
 pub use aws_sdk_apigateway;
 
-async fn apigateway_client(region: Option<&'static str>) -> ApiGatewayClient {
+#[cached]
+pub async fn apigateway<'client>(region: Option<&'static str>) -> ApiGatewayClient {
     ApiGatewayClient::new(&in_region(region).await)
-}
-
-static APIGATEWAY: OnceCell<ApiGatewayClient> = OnceCell::const_new();
-
-pub async fn apigateway<'client>(region: Option<&'static str>) -> &'client ApiGatewayClient {
-    APIGATEWAY.get_or_init(|| apigateway_client(region)).await
 }

--- a/src/services/cloudformation.rs
+++ b/src/services/cloudformation.rs
@@ -1,20 +1,11 @@
 use crate::services::in_region;
 use aws_sdk_cloudformation::Client as CloudformationClient;
-use tokio::sync::OnceCell;
 
 // Re-export
 pub use aws_sdk_cloudformation;
+use cached::proc_macro::cached;
 
-async fn cloudformation_client(region: Option<&'static str>) -> CloudformationClient {
+#[cached]
+pub async fn cloudformation(region: Option<&'static str>) -> CloudformationClient {
     CloudformationClient::new(&in_region(region).await)
-}
-
-static CLOUDFORMATION: OnceCell<CloudformationClient> = OnceCell::const_new();
-
-pub async fn cloudformation<'client>(
-    region: Option<&'static str>,
-) -> &'client CloudformationClient {
-    CLOUDFORMATION
-        .get_or_init(|| cloudformation_client(region))
-        .await
 }

--- a/src/services/cognitoidentityprovider.rs
+++ b/src/services/cognitoidentityprovider.rs
@@ -1,16 +1,11 @@
 use crate::services::in_region;
 use aws_sdk_cognitoidentityprovider::Client as CognitoIDPClient;
-use tokio::sync::OnceCell;
+use cached::proc_macro::cached;
 
 // Re-export
 pub use aws_sdk_cognitoidentityprovider;
 
-async fn cognito_client(region: Option<&'static str>) -> CognitoIDPClient {
+#[cached]
+pub async fn cognito(region: Option<&'static str>) -> CognitoIDPClient {
     CognitoIDPClient::new(&in_region(region).await)
-}
-
-static COGNITO: OnceCell<CognitoIDPClient> = OnceCell::const_new();
-
-pub async fn cognito<'client>(region: Option<&'static str>) -> &'client CognitoIDPClient {
-    COGNITO.get_or_init(|| cognito_client(region)).await
 }

--- a/src/services/dynamodb.rs
+++ b/src/services/dynamodb.rs
@@ -1,7 +1,7 @@
 use aws_sdk_dynamodb::{config::Builder as ConfigBuilder, Client as DynamoDBClient, Endpoint};
 use aws_types::region::Region;
+use cached::proc_macro::cached;
 use http::Uri;
-use tokio::sync::OnceCell;
 
 // Re-export
 pub use aws_sdk_dynamodb;
@@ -30,8 +30,7 @@ async fn dynamodb_client(region: Option<&'static str>) -> DynamoDBClient {
     }
 }
 
-pub static CLIENT: OnceCell<DynamoDBClient> = OnceCell::const_new();
-
-pub async fn dynamodb<'client>(region: Option<&'static str>) -> &'client DynamoDBClient {
-    CLIENT.get_or_init(|| dynamodb_client(region)).await
+#[cached]
+pub async fn dynamodb(region: Option<&'static str>) -> DynamoDBClient {
+    dynamodb_client(region).await
 }

--- a/src/services/iot.rs
+++ b/src/services/iot.rs
@@ -1,16 +1,11 @@
 use crate::services::in_region;
 use aws_sdk_iot::Client as IotClient;
-use tokio::sync::OnceCell;
+use cached::proc_macro::cached;
 
 // Re-export
 pub use aws_sdk_iot;
 
-async fn iot_client(region: Option<&'static str>) -> IotClient {
+#[cached]
+pub async fn iot(region: Option<&'static str>) -> IotClient {
     IotClient::new(&in_region(region).await)
-}
-
-static IOT: OnceCell<IotClient> = OnceCell::const_new();
-
-pub async fn iot<'client>(region: Option<&'static str>) -> &'client IotClient {
-    IOT.get_or_init(|| iot_client(region)).await
 }

--- a/src/services/lambda.rs
+++ b/src/services/lambda.rs
@@ -1,16 +1,11 @@
 use crate::services::in_region;
 use aws_sdk_lambda::Client as LambdaClient;
-use tokio::sync::OnceCell;
+use cached::proc_macro::cached;
 
 // Re-export
 pub use aws_sdk_lambda;
 
-async fn lambda_client(region: Option<&'static str>) -> LambdaClient {
+#[cached]
+pub async fn lambda(region: Option<&'static str>) -> LambdaClient {
     LambdaClient::new(&in_region(region).await)
-}
-
-static LAMBDA: OnceCell<LambdaClient> = OnceCell::const_new();
-
-pub async fn lambda<'client>(region: Option<&'static str>) -> &'client LambdaClient {
-    LAMBDA.get_or_init(|| lambda_client(region)).await
 }

--- a/src/services/organizations.rs
+++ b/src/services/organizations.rs
@@ -1,18 +1,11 @@
 use crate::services::in_region;
 use aws_sdk_organizations::Client as OrganizationsClient;
-use tokio::sync::OnceCell;
 
 // Re-export
 pub use aws_sdk_organizations;
+use cached::proc_macro::cached;
 
-async fn organizations_client(region: Option<&'static str>) -> OrganizationsClient {
+#[cached]
+pub async fn organizations(region: Option<&'static str>) -> OrganizationsClient {
     OrganizationsClient::new(&in_region(region).await)
-}
-
-static ORGANIZATIONS: OnceCell<OrganizationsClient> = OnceCell::const_new();
-
-pub async fn organizations<'client>(region: Option<&'static str>) -> &'client OrganizationsClient {
-    ORGANIZATIONS
-        .get_or_init(|| organizations_client(region))
-        .await
 }

--- a/src/services/s3.rs
+++ b/src/services/s3.rs
@@ -1,16 +1,11 @@
 use crate::services::in_region;
 use aws_sdk_s3::Client as S3Client;
-use tokio::sync::OnceCell;
+use cached::proc_macro::cached;
 
 // Re-export
 pub use aws_sdk_s3;
 
-async fn s3_client(region: Option<&'static str>) -> S3Client {
+#[cached]
+pub async fn s3(region: Option<&'static str>) -> S3Client {
     S3Client::new(&in_region(region).await)
-}
-
-static S3: OnceCell<S3Client> = OnceCell::const_new();
-
-pub async fn s3<'client>(region: Option<&'static str>) -> &'client S3Client {
-    S3.get_or_init(|| s3_client(region)).await
 }

--- a/src/services/secretsmanager.rs
+++ b/src/services/secretsmanager.rs
@@ -1,20 +1,11 @@
 use crate::services::in_region;
 use aws_sdk_secretsmanager::Client as SecretsManagerClient;
-use tokio::sync::OnceCell;
+use cached::proc_macro::cached;
 
 // Re-export
 pub use aws_sdk_secretsmanager;
 
-async fn secrets_manager_client(region: Option<&'static str>) -> SecretsManagerClient {
+#[cached]
+pub async fn secrets_manager(region: Option<&'static str>) -> SecretsManagerClient {
     SecretsManagerClient::new(&in_region(region).await)
-}
-
-static SECRETS_MANAGER: OnceCell<SecretsManagerClient> = OnceCell::const_new();
-
-pub async fn secrets_manager<'client>(
-    region: Option<&'static str>,
-) -> &'client SecretsManagerClient {
-    SECRETS_MANAGER
-        .get_or_init(|| secrets_manager_client(region))
-        .await
 }

--- a/src/services/ssm.rs
+++ b/src/services/ssm.rs
@@ -1,16 +1,11 @@
 use crate::services::in_region;
 use aws_sdk_ssm::Client as SSMClient;
-use tokio::sync::OnceCell;
+use cached::proc_macro::cached;
 
 // Re-export
 pub use aws_sdk_ssm;
 
-async fn ssm_client(region: Option<&'static str>) -> SSMClient {
+#[cached]
+pub async fn ssm(region: Option<&'static str>) -> SSMClient {
     SSMClient::new(&in_region(region).await)
-}
-
-static SSM: OnceCell<SSMClient> = OnceCell::const_new();
-
-pub async fn ssm<'client>(region: Option<&'static str>) -> &'client SSMClient {
-    SSM.get_or_init(|| ssm_client(region)).await
 }

--- a/src/services/sts.rs
+++ b/src/services/sts.rs
@@ -1,16 +1,11 @@
 use crate::services::in_region;
 use aws_sdk_sts::Client as STSClient;
-use tokio::sync::OnceCell;
+use cached::proc_macro::cached;
 
 // Re-export
 pub use aws_sdk_sts;
 
-async fn sts_client(region: Option<&'static str>) -> STSClient {
+#[cached]
+pub async fn sts(region: Option<&'static str>) -> STSClient {
     STSClient::new(&in_region(region).await)
-}
-
-static STS: OnceCell<STSClient> = OnceCell::const_new();
-
-pub async fn sts<'client>(region: Option<&'static str>) -> &'client STSClient {
-    STS.get_or_init(|| sts_client(region)).await
 }


### PR DESCRIPTION
Before this PR, if one did
```
apigateway(Some("eu-west-1"));
apigateway(Some("eu-west-2"));
```

The second call would return a client for "eu-west-1".